### PR TITLE
[Hotfix] Transform to string when `yaml.load` is boolean value

### DIFF
--- a/drucker/utils/__init__.py
+++ b/drucker/utils/__init__.py
@@ -20,7 +20,7 @@ class DruckerConfig:
         config = dict()
         if settings_yaml is not None:
             config = yaml.load(open(settings_yaml, 'r'))
-        self.TEST_MODE = os.getenv("DRUCKER_TEST_MODE", config.get("test", "False")) == 'True'
+        self.TEST_MODE = os.getenv("DRUCKER_TEST_MODE", str(config.get("test", "False"))) == 'True'
         self.SERVICE_PORT = os.getenv("DRUCKER_SERVICE_PORT", config.get("app.port", "5000"))
         self.APPLICATION_NAME = os.getenv("DRUCKER_APPLICATION_NAME", config["app.name"])
         self.SERVICE_NAME = os.getenv("DRUCKER_SERVICE_NAME", config["app.service.name"])

--- a/drucker/utils/__init__.py
+++ b/drucker/utils/__init__.py
@@ -20,7 +20,7 @@ class DruckerConfig:
         config = dict()
         if settings_yaml is not None:
             config = yaml.load(open(settings_yaml, 'r'))
-        self.TEST_MODE = os.getenv("DRUCKER_TEST_MODE", str(config.get("test", "False"))) == 'True'
+        self.TEST_MODE = str(os.getenv("DRUCKER_TEST_MODE", config.get("test", "False"))).lower() == 'true'
         self.SERVICE_PORT = os.getenv("DRUCKER_SERVICE_PORT", config.get("app.port", "5000"))
         self.APPLICATION_NAME = os.getenv("DRUCKER_APPLICATION_NAME", config["app.name"])
         self.SERVICE_NAME = os.getenv("DRUCKER_SERVICE_NAME", config["app.service.name"])


### PR DESCRIPTION
## What is this PR for?

There is the handling difference about boolean value between `os.getenv` and `yaml.load`. `yaml.load` automatically transform boolean value as boolean type. This PR fix it to handle it in the same way as `os.getenv`.

## This PR includes

- Add `str()` when boolean value of `yaml.load`

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

Run it without using environment variable.
