### PR TITLE
Check if invalid filepath specified then raise Exception

### DIFF
--- a/drucker/drucker_dashboard_servicer.py
+++ b/drucker/drucker_dashboard_servicer.py
@@ -99,7 +99,7 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
         self.logger.error(str(error))
         self.logger.error(traceback.format_exc())
 
-    def check_invalid_upload(self, filename: str) -> bool:
+    def is_valid_upload_filename(self, filename: str) -> bool:
         if Path(filename).name == filename:
             return True
         return False
@@ -131,7 +131,7 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
                 model_data = request.data
                 f.write(model_data)
             f.close()
-        if not self.check_invalid_upload(save_path):
+        if not self.is_valid_upload_filename(save_path):
             raise Exception(f'Error: Invalid model path specified -> {save_path}')
         model_path = self.app.get_model_path(save_path)
         Path(model_path).parent.mkdir(parents=True, exist_ok=True)
@@ -170,7 +170,7 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
         """
         first_req = next(request_iterator)
         save_path = first_req.data_path
-        if not self.check_invalid_upload(save_path):
+        if not self.is_valid_upload_filename(save_path):
             raise Exception(f'Error: Invalid evaluation file specified -> {save_path}')
 
         test_data = b''.join([first_req.data] + [r.data for r in request_iterator])

--- a/drucker/drucker_dashboard_servicer.py
+++ b/drucker/drucker_dashboard_servicer.py
@@ -99,6 +99,11 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
         self.logger.error(str(error))
         self.logger.error(traceback.format_exc())
 
+    def check_invalid_upload(self, filename: str) -> bool:
+        if Path(filename).name == filename:
+            return True
+        return False
+
     def ServiceInfo(self,
                     request: drucker_pb2.ServiceInfoRequest,
                     context: _Context
@@ -126,6 +131,8 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
                 model_data = request.data
                 f.write(model_data)
             f.close()
+        if not self.check_invalid_upload(save_path):
+            raise Exception(f'Error: Invalid model path specified -> {save_path}')
         model_path = self.app.get_model_path(save_path)
         Path(model_path).parent.mkdir(parents=True, exist_ok=True)
         shutil.move(tmp_path, model_path)
@@ -163,6 +170,8 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
         """
         first_req = next(request_iterator)
         save_path = first_req.data_path
+        if not self.check_invalid_upload(save_path):
+            raise Exception(f'Error: Invalid evaluation file specified -> {save_path}')
 
         test_data = b''.join([first_req.data] + [r.data for r in request_iterator])
         result, details = self.app.evaluate(test_data)

--- a/drucker/test/test_dashboard_servicer.py
+++ b/drucker/test/test_dashboard_servicer.py
@@ -15,7 +15,7 @@ class DruckerWorkerServicerTest(unittest.TestCase):
     def test_ServiceInfo(self):
         servicer = DruckerDashboardServicer(logger=system_logger, app=app)
         request = drucker_pb2.ServiceInfoRequest()
-        response = servicer.ServiceInfo(request=request, context=None)
+        response = servicer.ServiceInfo(request=request, context=Mock())
         self.assertEqual(response.application_name, 'test')
         self.assertEqual(response.service_name, 'test-001')
         self.assertEqual(response.service_level, 'development')
@@ -27,12 +27,13 @@ class DruckerWorkerServicerTest(unittest.TestCase):
     def test_UploadModel(self, mock_file, mock_path_class, mock_shutil, mock_uuid):
         # mock setting
         mock_path_class.return_value = Mock()
+        mock_path_class.return_value.name = 'my_path'
         mock_shutil.move.return_value = True
         mock_uuid.uuid4.return_value = Mock(hex='my_uuid')
 
         servicer = DruckerDashboardServicer(logger=system_logger, app=app)
         requests = iter(drucker_pb2.UploadModelRequest(path='my_path', data=b'data') for _ in range(1, 3))
-        response = servicer.UploadModel(request_iterator=requests, context=None)
+        response = servicer.UploadModel(requests, Mock())
 
         tmp_path = './test-model/test/my_uuid'
         save_path = './test-model/test/my_path'
@@ -44,6 +45,23 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         ], any_order=True)
         mock_shutil.move.assert_called_once_with(tmp_path, save_path)
 
+    @patch('drucker.drucker_dashboard_servicer.uuid')
+    @patch('drucker.drucker_dashboard_servicer.shutil')
+    @patch('drucker.drucker_dashboard_servicer.Path')
+    @patch("builtins.open", new_callable=mock_open)
+    def test_InvalidUploadModel(self, mock_file, mock_path_class, mock_shutil, mock_uuid):
+        # mock setting
+        mock_path_class.return_value = Mock()
+        mock_path_class.return_value.name = 'my_path'
+        mock_shutil.move.return_value = True
+        mock_uuid.uuid4.return_value = Mock(hex='my_uuid')
+
+        servicer = DruckerDashboardServicer(logger=system_logger, app=app)
+        requests = iter(drucker_pb2.UploadModelRequest(path='../../../my_path', data=b'data') for _ in range(1, 3))
+        response = servicer.UploadModel(requests, Mock())
+
+        self.assertEqual(response.status, 0)
+
     @patch('drucker.test.DummyApp')
     def test_SwitchModel(self, mock_app):
         # mock setting
@@ -52,7 +70,7 @@ class DruckerWorkerServicerTest(unittest.TestCase):
 
         servicer = DruckerDashboardServicer(logger=system_logger, app=mock_app)
         request = drucker_pb2.SwitchModelRequest(path='my_path')
-        response = servicer.SwitchModel(request=request, context=None)
+        response = servicer.SwitchModel(request, Mock())
 
         self.assertEqual(response.status, 1)
         mock_app.load_model.assert_called_once_with('test/my_path')
@@ -67,7 +85,7 @@ class DruckerWorkerServicerTest(unittest.TestCase):
 
         servicer = DruckerDashboardServicer(logger=system_logger, app=app)
         requests = iter(drucker_pb2.EvaluateModelRequest(data_path='my_path', data=b'data_') for _ in range(1, 3))
-        response = servicer.EvaluateModel(request_iterator=requests, context=None)
+        response = servicer.EvaluateModel(requests, Mock())
 
         self.assertEqual(round(response.metrics.num, 3), eval_result.num)
         self.assertEqual(round(response.metrics.accuracy, 3), eval_result.accuracy)
@@ -82,6 +100,23 @@ class DruckerWorkerServicerTest(unittest.TestCase):
             call("./eval/test/my_path_eval_res.pkl", "wb"),
             call("./eval/test/my_path_eval_detail.pkl", "wb")
         ], any_order=True)
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch('drucker.drucker_dashboard_servicer.pickle')
+    @patch('drucker.drucker_dashboard_servicer.Path')
+    def test_InvalidEvalauteModel(self, mock_path_class, mock_pickle, mock_file):
+        # mock setting
+        mock_path_class.return_value = Mock()
+        mock_path_class.return_value.name = 'my_path'
+        eval_result = EvaluateResult(1, 0.8, [0.7], [0.6], [0.5], {'dummy': 0.4})
+        details = [EvaluateDetail('test_input', 'test_label', PredictResult('pre_label', 0.9), False)]
+        app.evaluate = Mock(return_value=(eval_result, details))
+
+        servicer = DruckerDashboardServicer(logger=system_logger, app=app)
+        requests = iter(drucker_pb2.EvaluateModelRequest(data_path='../../my_path', data=b'data_') for _ in range(1, 3))
+        response = servicer.EvaluateModel(requests, Mock())
+
+        self.assertEqual(response.metrics.num, 0)
 
     def test_error_handling(self):
         # mock setting


### PR DESCRIPTION
## What is this PR for?

The current process allows to save files to the system file location when user specify the relative path via API. This PR checks the `filename` includes filepath or not.

## This PR includes

- Add filename checker
- Add unittest

## What type of PR is it?

Bugfix

## What is the issue?

#16 

## How should this be tested?

```
client = DruckerDashClient(logger=logger, host=host)
response = client.run_upload("../../../../../../../tmp/NEW_FILE", bytes('uploaded!!!!\n', 'utf-8'))
print(response)
```